### PR TITLE
Small fix and new forwards for game modes

### DIFF
--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -369,16 +369,12 @@ public plugin_precache() {
 	new fwPreConfig, fwPostConfig, fwReturnTemp;
 	
 	fwPreConfig = CreateMultiForward("agmodx_pre_config", ET_IGNORE);
-	if (fwPreConfig < 0) log_amx("Error creating forward");
 	
 	fwPostConfig = CreateMultiForward("agmodx_post_config", ET_IGNORE);
-	if (fwPostConfig < 0) log_amx("Error creating forward");
 	
 	gFwPause = CreateMultiForward("agmodx_pause", ET_IGNORE);
-	if (gFwPause < 0) log_amx("Error creating forward");
 
 	gFwPreIntermissionMode = CreateMultiForward("agmodx_pre_intermission_mode", ET_IGNORE);
-	if (gFwPreIntermissionMode < 0) log_amx("Error creating forward");
 
 	// Load mode cvars
 	new mode[32];

--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -217,6 +217,7 @@ new gCvarCoreBlockSpec;
 new gCvarMatchRunning;
 
 new gFwPause;
+new gFwPreIntermissionMode;
 
 new const gWeaponClass[][] = {
 	"weapon_357",
@@ -375,6 +376,9 @@ public plugin_precache() {
 	
 	gFwPause = CreateMultiForward("agmodx_pause", ET_IGNORE);
 	if (gFwPause < 0) log_amx("Error creating forward");
+
+	gFwPreIntermissionMode = CreateMultiForward("agmodx_pre_intermission_mode", ET_IGNORE);
+	if (gFwPreIntermissionMode < 0) log_amx("Error creating forward");
 
 	// Load mode cvars
 	new mode[32];
@@ -2998,6 +3002,8 @@ public EventIntermissionMode() {
 }
 
 public StartIntermissionMode() {
+	new fwReturnTemp;
+	ExecuteForward(gFwPreIntermissionMode, fwReturnTemp);
 	new ent = create_entity("game_end");
 	if (is_valid_ent(ent))
 		ExecuteHamB(Ham_Use, ent, 0, 0, 1.0, 0.0);

--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -889,7 +889,6 @@ public StartVersus() {
 	gIsSuddenDeath = false;
 	
 	set_pcvar_num(gCvarMatchRunning, 0); // reset to 0 so plugins hooking this cvar can be triggered
-	set_pcvar_num(gCvarMatchRunning, 1);
 
 	// reset score and freeze players who are going to play versus
 	new players[MAX_PLAYERS], numPlayers;
@@ -904,6 +903,7 @@ public StartVersus() {
 	}
 
 	gStartVersusTime = 9;
+	set_pcvar_num(gCvarMatchRunning, 1);
 	StartVersusCountdown();
 }
 

--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -216,6 +216,8 @@ new gCvarBanChargers;
 new gCvarCoreBlockSpec;
 new gCvarMatchRunning;
 
+new gFwPause;
+
 new const gWeaponClass[][] = {
 	"weapon_357",
 	"weapon_9mmAR",
@@ -362,13 +364,26 @@ public plugin_precache() {
 	// reset this always
 	gCvarMatchRunning = create_cvar("sv_ag_match_running", "0");
 	set_pcvar_string(gCvarMatchRunning, "0");
+	
+	new fwPreConfig, fwPostConfig, fwReturnTemp;
+	
+	fwPreConfig = CreateMultiForward("agmodx_pre_config", ET_IGNORE);
+	if (fwPreConfig < 0) log_amx("Error creating forward");
+	
+	fwPostConfig = CreateMultiForward("agmodx_post_config", ET_IGNORE);
+	if (fwPostConfig < 0) log_amx("Error creating forward");
+	
+	gFwPause = CreateMultiForward("agmodx_pause", ET_IGNORE);
+	if (gFwPause < 0) log_amx("Error creating forward");
 
 	// Load mode cvars
 	new mode[32];
 	get_pcvar_string(gCvarGameMode, mode, charsmax(mode));
 
+	ExecuteForward(fwPreConfig, fwReturnTemp);
 	server_cmd("exec gamemodes/%s.cfg", mode);
 	server_exec();
+	ExecuteForward(fwPostConfig, fwReturnTemp);
 }
 
 public plugin_natives() {
@@ -2819,7 +2834,9 @@ PauseGame() {
 }
 
 public CmdPauseAg(id) {
+	new fwReturnTemp;
 	set_cvar_num("pausable", 0);	
+	ExecuteForward(gFwPause, fwReturnTemp);
 	return PLUGIN_HANDLED;
 }
 

--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -217,7 +217,6 @@ new gCvarCoreBlockSpec;
 new gCvarMatchRunning;
 
 new gFwPause;
-new gFwPreIntermissionMode;
 
 new const gWeaponClass[][] = {
 	"weapon_357",
@@ -373,8 +372,6 @@ public plugin_precache() {
 	fwPostConfig = CreateMultiForward("agmodx_post_config", ET_IGNORE);
 	
 	gFwPause = CreateMultiForward("agmodx_pause", ET_IGNORE);
-
-	gFwPreIntermissionMode = CreateMultiForward("agmodx_pre_intermission_mode", ET_IGNORE);
 
 	// Load mode cvars
 	new mode[32];
@@ -3008,7 +3005,6 @@ public EventIntermissionMode() {
 
 public StartIntermissionMode() {
 	new fwReturnTemp;
-	ExecuteForward(gFwPreIntermissionMode, fwReturnTemp);
 	new ent = create_entity("game_end");
 	if (is_valid_ent(ent))
 		ExecuteHamB(Ham_Use, ent, 0, 0, 1.0, 0.0);

--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -3004,7 +3004,6 @@ public EventIntermissionMode() {
 }
 
 public StartIntermissionMode() {
-	new fwReturnTemp;
 	new ent = create_entity("game_end");
 	if (is_valid_ent(ent))
 		ExecuteHamB(Ham_Use, ent, 0, 0, 1.0, 0.0);

--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -919,6 +919,11 @@ public StartVersus() {
 
 	gStartVersusTime = 9;
 	set_pcvar_num(gCvarMatchRunning, 1);
+
+	new fwCountdownStart, fwReturnTemp;
+	fwCountdownStart = CreateMultiForward("agmodx_countdown_start", ET_IGNORE);
+	ExecuteForward(fwCountdownStart, fwReturnTemp);
+
 	StartVersusCountdown();
 }
 
@@ -926,6 +931,10 @@ public StartVersusCountdown() {
 	PlayNumSound(0, gStartVersusTime);
 
 	if (gStartVersusTime == 0) {
+		new fwCountdownEnd, fwReturnTemp;
+		fwCountdownEnd = CreateMultiForward("agmodx_countdown_end", ET_IGNORE);
+		ExecuteForward(fwCountdownEnd, fwReturnTemp);
+		
 		gVersusStarted = true;
 
 		gBlockCmdDrop = false;


### PR DESCRIPTION
- Fix sv_ag_match_running not working as intended on gamemodes.
- Added 5 forwards: agmodx_pre_config, agmodx_post_config, agmodx_pause, agmodx_countdown_start and agmodx_countdown_end. Useful for gamemodes.