### PR TITLE
Register callvote command as an alias for vote

### DIFF
--- a/valve/addons/amxmodx/scripting/agmodx.sma
+++ b/valve/addons/amxmodx/scripting/agmodx.sma
@@ -439,6 +439,7 @@ public plugin_init() {
 	ag_register_concmd("aglistvotes", "CmdVoteHelp", ADMIN_ALL, "AGCMD_LISTVOTES", _, true);
 	ag_register_concmd("timeleft", "CmdTimeLeft", ADMIN_ALL, "AGCMD_TIMELEFT", _, true);
 	ag_register_clcmd("vote", "CmdVote", ADMIN_ALL, "AGCMD_VOTE", _, true);
+	ag_register_clcmd("callvote", "CmdVote", ADMIN_ALL, "AGCMD_VOTE", _, true);
 	ag_register_clcmd("yes", "CmdVoteYes", ADMIN_ALL, "AGCMD_YES", _, true);
 	ag_register_clcmd("no", "CmdVoteNo", ADMIN_ALL, "AGCMD_NO", _, true);
 	ag_register_clcmd("say !yes", "CmdVoteYes_Say", ADMIN_ALL, "AGCMD_YES", _, true);


### PR DESCRIPTION
Adrenaline Gamer has the `callvote` command as an alternative to `vote`, I know for a fact that this alias is sometimes used by some other AMXX plugins to issue player votes, would be nice to support it.